### PR TITLE
fix: Issue #230 — Oracle NPE + remarksReporting

### DIFF
--- a/src/main/java/com/ifengxue/plugin/gui/DatabaseSettingsDialog.java
+++ b/src/main/java/com/ifengxue/plugin/gui/DatabaseSettingsDialog.java
@@ -38,6 +38,7 @@ import com.intellij.ui.components.JBScrollPane;
 import fastjdbc.FastJdbc;
 import fastjdbc.NoPoolDataSource;
 import fastjdbc.SimpleFastJdbc;
+import java.util.Properties;
 import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
 import java.io.File;
@@ -181,6 +182,11 @@ public class DatabaseSettingsDialog extends DialogWrapper {
     String connectionUrl = databaseSettings.getTextConnectionUrl().getText().trim();
     String driverPath = databaseSettings.getTextDriverPath().getText().trim();
     String driverClass = databaseSettings.getTextDriverClass().getText().trim();
+    Properties connectionProps = null;
+    if (driverClass.toLowerCase().contains("oracle")) {
+      connectionProps = new Properties();
+      connectionProps.setProperty("remarksReporting", "true");
+    }
     saveTextField(host, port, username, password);
     String connectionUrlRef = Holder.getJdbcConfigUtil()
         .tryParseUrl(driverClass, host, port, username, password, database, connectionUrl);
@@ -216,7 +222,7 @@ public class DatabaseSettingsDialog extends DialogWrapper {
       // 尝试获取连接
       try (Connection ignored = DriverManager.getConnection(connectionUrlRef, username, password)) {
         FastJdbc fastJdbc = new SimpleFastJdbc(
-            new NoPoolDataSource(connectionUrlRef, username, password));
+            new NoPoolDataSource(connectionUrlRef, username, password, connectionProps));
         Holder.registerFastJdbc(fastJdbc);
       } catch (SQLException se) {
         ApplicationManager.getApplication().invokeLater(() -> {

--- a/src/main/java/fastjdbc/NoPoolDataSource.java
+++ b/src/main/java/fastjdbc/NoPoolDataSource.java
@@ -5,6 +5,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
 
@@ -13,21 +14,37 @@ public class NoPoolDataSource implements DataSource {
   private final String url;
   private final String username;
   private final String password;
+  private final Properties connectionProperties;
 
   public NoPoolDataSource(String url, String username, String password) {
+    this(url, username, password, null);
+  }
+
+  public NoPoolDataSource(String url, String username, String password, Properties connectionProperties) {
     this.url = url;
     this.username = username;
     this.password = password;
+    this.connectionProperties = connectionProperties;
   }
 
   @Override
   public Connection getConnection() throws SQLException {
-    return DriverManager.getConnection(url, username, password);
+    return DriverManager.getConnection(url, buildConnectionInfo(username, password));
   }
 
   @Override
   public Connection getConnection(String username, String password) throws SQLException {
-    return DriverManager.getConnection(url, username, password);
+    return DriverManager.getConnection(url, buildConnectionInfo(username, password));
+  }
+
+  private Properties buildConnectionInfo(String user, String pass) {
+    Properties info = new Properties();
+    info.setProperty("user", user);
+    info.setProperty("password", pass);
+    if (connectionProperties != null) {
+      info.putAll(connectionProperties);
+    }
+    return info;
   }
 
   @Override

--- a/src/main/resources/jdbc_config.json
+++ b/src/main/resources/jdbc_config.json
@@ -40,5 +40,15 @@
     "username": "root",
     "schema": "",
     "url": "jdbc:mariadb://{host}:{port}/{database}?useSSL=false&useUnicode=true&characterEncoding=UTF-8"
+  },
+  {
+    "vendor": "Oracle",
+    "driver": "oracle.jdbc.OracleDriver",
+    "host": "localhost",
+    "port": 1521,
+    "username": "system",
+    "database": "orcl",
+    "schema": "",
+    "url": "jdbc:oracle:thin:@//{host}:{port}/{database}"
   }
 ]


### PR DESCRIPTION
## Summary

Fixes two root causes from **Issue #230** — Oracle JDBC driver integration failures for large Oracle schemas:

### 1. NPE in ServiceSourceParser &amp; ControllerSourceParser (🔴 High)
**Root cause**: `table.getPrimaryKeyClassType()` returns `null` when Oracle JDBC can't retrieve column/primary-key metadata. `ServiceSourceParser` and `ControllerSourceParser` called `.getSimpleName()` unconditionally → NPE → silently caught → Service/Controller files never generated (only Entity skeleton produced).

**Fix**: Null-safe `Optional.ofNullable(...).map(getWrapperClass).map(getSimpleName).orElse(\&quot;Void\&quot;)` — matching the existing pattern in `JpaRepositorySourceParser`.

### 2. Oracle table/column comments always empty (🟡 Medium)
**Root cause**: Oracle JDBC driver does **not** populate the `REMARKS` column in `DatabaseMetaData.getTables()`/`getColumns()` unless `remarksReporting=true` is set in connection properties. Without this, `ALL_TAB_COMMENTS` and `ALL_COL_COMMENTS` views are never queried.

**Fix**: Auto-detect Oracle driver class, set `remarksReporting=true` connection property, pass through `NoPoolDataSource` → `DriverManager.getConnection(url, info)`.

### 3. Oracle JDBC config template
Added Oracle driver entry to `jdbc_config.json` for easier Oracle connection setup.

---

**Changed files**: 5 files, +48/−5
- `src/main/java/com/ifengxue/plugin/generator/source/ControllerSourceParser.java`
- `src/main/java/com/ifengxue/plugin/generator/source/ServiceSourceParser.java`
- `src/main/java/fastjdbc/NoPoolDataSource.java`
- `src/main/java/com/ifengxue/plugin/gui/DatabaseSettingsDialog.java`
- `src/main/resources/jdbc_config.json`

Closes #230